### PR TITLE
Postgres migrations

### DIFF
--- a/src/Blogifier.Core/Blogifier.Core.csproj
+++ b/src/Blogifier.Core/Blogifier.Core.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Blogifier.Core/Data/Migrations/20170616042349_InitBlogifierDb.Designer.cs
+++ b/src/Blogifier.Core/Data/Migrations/20170616042349_InitBlogifierDb.Designer.cs
@@ -16,7 +16,7 @@ namespace Blogifier.Core.Data.Migrations
         {
             modelBuilder
                 .HasAnnotation("ProductVersion", "1.1.1")
-                .HasAnnotation("Npgsql:ValueGeneratedOnAdd", true)
+                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
                 .HasAnnotation("MySql:ValueGeneratedOnAdd", true)
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 

--- a/src/Blogifier.Core/Data/Migrations/20170616042349_InitBlogifierDb.cs
+++ b/src/Blogifier.Core/Data/Migrations/20170616042349_InitBlogifierDb.cs
@@ -14,7 +14,7 @@ namespace Blogifier.Core.Data.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(nullable: false)
-                        .Annotation("Npgsql:ValueGeneratedOnAdd", true)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
                         .Annotation("MySql:ValueGeneratedOnAdd", true)
                         .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
                     Description = table.Column<string>(maxLength: 450, nullable: true),
@@ -36,7 +36,7 @@ namespace Blogifier.Core.Data.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(nullable: false)
-                        .Annotation("Npgsql:ValueGeneratedOnAdd", true)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
                         .Annotation("MySql:ValueGeneratedOnAdd", true)
                         .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
                     CustomKey = table.Column<string>(maxLength: 140, nullable: false),
@@ -56,7 +56,7 @@ namespace Blogifier.Core.Data.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(nullable: false)
-                        .Annotation("Npgsql:ValueGeneratedOnAdd", true)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
                         .Annotation("MySql:ValueGeneratedOnAdd", true)
                         .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
                     AuthorEmail = table.Column<string>(maxLength: 160, nullable: false),
@@ -82,7 +82,7 @@ namespace Blogifier.Core.Data.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(nullable: false)
-                        .Annotation("Npgsql:ValueGeneratedOnAdd", true)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
                         .Annotation("MySql:ValueGeneratedOnAdd", true)
                         .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
                     AssetType = table.Column<int>(nullable: false),
@@ -110,7 +110,7 @@ namespace Blogifier.Core.Data.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(nullable: false)
-                        .Annotation("Npgsql:ValueGeneratedOnAdd", true)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
                         .Annotation("MySql:ValueGeneratedOnAdd", true)
                         .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
                     Content = table.Column<string>(nullable: false),
@@ -139,7 +139,7 @@ namespace Blogifier.Core.Data.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(nullable: false)
-                        .Annotation("Npgsql:ValueGeneratedOnAdd", true)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
                         .Annotation("MySql:ValueGeneratedOnAdd", true)
                         .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
                     BlogPostId = table.Column<int>(nullable: false),

--- a/src/Blogifier.Core/Data/Migrations/20171022164727_FeaturedPosts.Designer.cs
+++ b/src/Blogifier.Core/Data/Migrations/20171022164727_FeaturedPosts.Designer.cs
@@ -20,7 +20,7 @@ namespace Blogifier.Core.Data.Migrations
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "2.0.0-rtm-26452")
-                .HasAnnotation("Npgsql:ValueGeneratedOnAdd", true)
+                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
                 .HasAnnotation("MySql:ValueGeneratedOnAdd", true)
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 

--- a/src/Blogifier.Core/Data/Migrations/20171022164727_FeaturedPosts.cs
+++ b/src/Blogifier.Core/Data/Migrations/20171022164727_FeaturedPosts.cs
@@ -11,21 +11,18 @@ namespace Blogifier.Core.Data.Migrations
             migrationBuilder.AddColumn<string>(
                 name: "Bio",
                 table: "Profiles",
-                type: "nvarchar(4000)",
                 maxLength: 4000,
                 nullable: true);
 
             migrationBuilder.AddColumn<bool>(
                 name: "IsFeatured",
                 table: "BlogPosts",
-                type: "bit",
                 nullable: false,
                 defaultValue: false);
 
             migrationBuilder.AddColumn<float>(
                 name: "Rating",
                 table: "BlogPosts",
-                type: "real",
                 nullable: false,
                 defaultValue: 0f);
         }

--- a/src/Blogifier.Core/Data/Migrations/BlogifierDbContextModelSnapshot.cs
+++ b/src/Blogifier.Core/Data/Migrations/BlogifierDbContextModelSnapshot.cs
@@ -19,7 +19,7 @@ namespace Blogifier.Core.Data.Migrations
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "2.0.0-rtm-26452")
-                .HasAnnotation("Npgsql:ValueGeneratedOnAdd", true)
+                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
                 .HasAnnotation("MySql:ValueGeneratedOnAdd", true)
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 


### PR DESCRIPTION
I received the errors below when running initial migrations against Postgres.  This PR has the changes I made locally to get migrations to run successfully.

```
The Npgsql:ValueGeneratedOnAdd annotation has been found in your migrations, but is no longer
 supported. Please replace it with '.Annotation("Npgsql:ValueGenerationStrategy",
 NpgsqlValueGenerationStrategy.SerialColumn)' where you want PostgreSQL serial 
(autoincrement) columns, and remove it in all other cases.
```
```
ALTER TABLE "Profiles" ADD "Bio" nvarchar(4000) NULL;
Npgsql.PostgresException (0x80004005): 42704: type "nvarchar" does not exist
```
I'm not thrilled about adding the Npgsql package reference needing to always be included, but I wasn't sure how to do this another way.

Note that the changes to the `FeaturedPosts.cs` migration shouldn't change how columns are created on SQL server.


