### PR TITLE
Fix Azure deployment by excluding ref assemblies

### DIFF
--- a/Blogifier.Web/Blogifier.Web.csproj
+++ b/Blogifier.Web/Blogifier.Web.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <UserSecretsId>aspnet-WebApp-369A2B28-7315-4454-AED5-A00184C38B6F</UserSecretsId>
+    <MvcRazorExcludeRefAssembliesFromPublish>false</MvcRazorExcludeRefAssembliesFromPublish>     
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I tried to deploy Blogifier directly using GitHub. But the app start failed with the following message:

    Cannot find compilation library location for package 'Microsoft.Win32.Registry'

To fix it I had to add the following line to the Blogifier.Web.csproj file:
`<MvcRazorExcludeRefAssembliesFromPublish>false</MvcRazorExcludeRefAssembliesFromPublish> `

That fixed the deployment for me and every push is now built and deployed automatically. 😄 