### PR TITLE
Add RuntimeIdentifiers and UseAppHost for add possibility publish as self-containted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
-
+.idea/
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/plugins/Common/Common.csproj
+++ b/plugins/Common/Common.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <product>Blogifier.Plugins.Common</product>
   </PropertyGroup>
 

--- a/plugins/Common/Common.csproj
+++ b/plugins/Common/Common.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <UseAppHost>true</UseAppHost>
     <product>Blogifier.Plugins.Common</product>
   </PropertyGroup>
 

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <UseAppHost>true</UseAppHost>
     <MvcRazorExcludeRefAssembliesFromPublish>false</MvcRazorExcludeRefAssembliesFromPublish>
     <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
   </PropertyGroup>

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <MvcRazorExcludeRefAssembliesFromPublish>false</MvcRazorExcludeRefAssembliesFromPublish>
     <MvcRazorCompileOnPublish>false</MvcRazorCompileOnPublish>
   </PropertyGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <Version>2.3.0.7</Version>
   </PropertyGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UseAppHost>true</UseAppHost>
     <Version>2.3.0.7</Version>
   </PropertyGroup>
 

--- a/src/Upgrade/Upgrade.csproj
+++ b/src/Upgrade/Upgrade.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
 </Project>

--- a/src/Upgrade/Upgrade.csproj
+++ b/src/Upgrade/Upgrade.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <UseAppHost>true</UseAppHost>
   </PropertyGroup>
 
 </Project>

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <IsPackable>false</IsPackable>
+    <UseAppHost>true</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
dotnet publish --self-contained 
was usefull for me, when i try use perf to sampling profiling under linux