### PR TITLE
Social field to objects

### DIFF
--- a/src/Blogifier/Views/Themes/CleanBlog/List.cshtml
+++ b/src/Blogifier/Views/Themes/CleanBlog/List.cshtml
@@ -2,7 +2,6 @@
 @{
     ListModel listModel = (ListModel)Model;
     ViewData["BlogTitle"] = listModel.Blog.Title;
-    var socials = await DataService.CustomFields.GetSocial();
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -96,7 +95,7 @@
     <hr>
 
     <!-- Footer -->
-    <partial name="~/Views/Themes/CleanBlog/Shared/Footer.cshtml" model="socials" view-data="ViewData" />
+    <partial name="~/Views/Themes/CleanBlog/Shared/Footer.cshtml" model="listModel.Blog.SocialFields" view-data="ViewData" />
 
 
     <!-- Bootstrap core JavaScript -->

--- a/src/Blogifier/Views/Themes/CleanBlog/Post.cshtml
+++ b/src/Blogifier/Views/Themes/CleanBlog/Post.cshtml
@@ -3,7 +3,6 @@
     PostModel postModel = (PostModel)Model;
     string cover = $"{Url.Content("~/")}{postModel.Post.Cover}";
     ViewData["BlogTitle"] = postModel.Blog.Title;
-    var socials = await DataService.CustomFields.GetSocial(postModel.Post.Author.Id);
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -79,7 +78,7 @@
     <hr>
 
     <!-- Footer -->
-    <partial name="~/Views/Themes/CleanBlog/Shared/Footer.cshtml" model="socials" view-data="ViewData" />
+    <partial name="~/Views/Themes/CleanBlog/Shared/Footer.cshtml" model="postModel.Post.SocialFields" view-data="ViewData" />
 
     <script src="~/themes/cleanblog/vendor/jquery/jquery.min.js"></script>
     <script src="~/themes/cleanblog/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>

--- a/src/Blogifier/Views/Themes/Philosophy/Post.cshtml
+++ b/src/Blogifier/Views/Themes/Philosophy/Post.cshtml
@@ -7,8 +7,6 @@
     PostModel postModel = (PostModel)Model;
     string cover = $"{Url.Content("~/")}{postModel.Post.Cover}";
     var catUrl = Url.Content("~/categories");
-    var socials = await DataService.CustomFields.GetSocial(postModel.Post.Author.Id);
-
     var cats = string.IsNullOrEmpty(postModel.Post.Categories)
         ? null : postModel.Post.Categories.Split(',').ToList();
 }
@@ -110,7 +108,7 @@
                         </p>
 
                         <ul class="s-content__author-social">
-                            @foreach (var field in socials)
+                            @foreach (var field in postModel.Post.SocialFields)
                             {
                             <li><a href="@field.Content">@field.Title</a></li>
                             }

--- a/src/Blogifier/Views/Themes/Philosophy/Shared/Footer.cshtml
+++ b/src/Blogifier/Views/Themes/Philosophy/Shared/Footer.cshtml
@@ -10,8 +10,6 @@
     var catsUnordered = await DataService.BlogPosts.Categories();
     var cats = catsUnordered.OrderByDescending(c => c.PostCount);
     var blog = await DataService.CustomFields.GetBlogSettings();
-
-    var socials = await DataService.CustomFields.GetSocial();
 }
 <!-- s-extra
 ================================================== -->
@@ -45,7 +43,7 @@
             <h3>About @blog.Title</h3>
             <p>@blog.Description</p>
             <ul class="about__social">
-                @foreach (var field in socials)
+                @foreach (var field in blog.SocialFields)
                 {
                 <li><a href="@field.Content"><i class="fa @field.Icon" aria-hidden="true"></i></a></li>
                 }
@@ -107,7 +105,7 @@
             <div class="col-two md-four mob-full s-footer__social">
                 <h4>@Localizer["social-accounts"]</h4>
                 <ul class="s-footer__linklist">
-                    @foreach (var field in socials)
+                    @foreach (var field in blog.SocialFields)
                     {
                     <li><a href="@field.Content">@field.Title</a></li>
                     }

--- a/src/Blogifier/Views/Themes/Philosophy/Shared/Header.cshtml
+++ b/src/Blogifier/Views/Themes/Philosophy/Shared/Header.cshtml
@@ -3,7 +3,6 @@
 @inject IJsonStringLocalizer<ListModel> Localizer
 @{
     var blog = await DataService.CustomFields.GetBlogSettings();
-    var socials = await DataService.CustomFields.GetSocial();
 }
 <header class="header">
     <div class="header__content row">
@@ -15,7 +14,7 @@
         </div>
 
         <ul class="header__social">
-            @foreach (var field in socials)
+            @foreach (var field in blog.SocialFields)
             {
             <li><a href="@field.Content"><i class="fa @field.Icon" aria-hidden="true"></i></a></li>
             }

--- a/src/Blogifier/Views/Themes/Standard/List.cshtml
+++ b/src/Blogifier/Views/Themes/Standard/List.cshtml
@@ -16,7 +16,7 @@
     <partial name="~/Views/Themes/Standard/Shared/Head.cshtml" />
 </head>
 <body class="home">
-    <partial name="~/Views/Themes/Standard/Shared/Header.cshtml" />
+    <partial name="~/Views/Themes/Standard/Shared/Header.cshtml" model="listModel.Blog.SocialFields"/>
 
     <div class="page-cover" style="background-image: url('@cover')">
         <h1 class="page-cover-title">

--- a/src/Blogifier/Views/Themes/Standard/Post.cshtml
+++ b/src/Blogifier/Views/Themes/Standard/Post.cshtml
@@ -11,7 +11,7 @@
     <partial name="~/Views/Themes/Standard/Shared/Head.cshtml" />
 </head>
 <body class="home">
-    <partial name="~/Views/Themes/Standard/Shared/Header.cshtml" />
+    <partial name="~/Views/Themes/Standard/Shared/Header.cshtml" model="postModel.Blog.SocialFields" />
 
     <article class="post-single">
         <div class="post-cover" style="background-image: url('@cover')"></div>

--- a/src/Blogifier/Views/Themes/Standard/Shared/Header.cshtml
+++ b/src/Blogifier/Views/Themes/Standard/Shared/Header.cshtml
@@ -1,14 +1,10 @@
-﻿@inject IDataService DataService
-@{ 
-    var socials = await DataService.CustomFields.GetSocial();
-}
-<header class="blog-header d-flex flex-column">
+﻿<header class="blog-header d-flex flex-column">
     <div class="container d-flex">
         <a href="~/blog" class="blog-logo my-auto d-flex">
             <img src="~/themes/standard/img/logo-white.png" alt="Blog Title" class="my-auto" />
         </a>
         <ul class="blog-social nav ml-auto my-auto">
-            @foreach (var field in socials)
+            @foreach (var field in Model)
             {
                 <li class="blog-social-item">
                     <a class="blog-social-link" target="_blank" href="@field.Content">

--- a/src/Blogifier/Views/Themes/Vizew/Post.cshtml
+++ b/src/Blogifier/Views/Themes/Vizew/Post.cshtml
@@ -1,13 +1,11 @@
 ﻿@using Blogifier.Core.Data
 @using Askmethat.Aspnet.JsonLocalizer.Localizer
-@inject IDataService DataService
 @inject IJsonStringLocalizer<ListModel> Localizer
 @{
     PostModel postModel = (PostModel)Model;
     string root = Url.Content("~/");
     string cover = $"{root}{postModel.Post.Cover}";
     var catUrl = Url.Content("~/categories");
-    var socials = await DataService.CustomFields.GetSocial(postModel.Post.Author.Id);
 }
 <!DOCTYPE html>
 <html lang="en">
@@ -171,7 +169,7 @@
                         <!-- ***** Single Widget ***** -->
                         <div class="single-widget share-post-widget mb-50">
                             <p>Share This Post</p>
-                            @foreach (var field in socials)
+                            @foreach (var field in postModel.Blog.SocialFields)
                             {
                             <a href="@field.Content" class="@field.Title.ToLower()"><i class="fa @field.Icon" aria-hidden="true"></i> @field.Title</a>
                             }
@@ -183,7 +181,7 @@
                                 <img class="author-avatar" src="~/@postModel.Post.Author.Avatar" alt="">
                                 <a href="#" class="author-name">@postModel.Post.Author.DisplayName</a>
                                 <div class="author-social-info">
-                                    @foreach (var field in socials)
+                                    @foreach (var field in postModel.Blog.SocialFields)
                                     {
                                     <a href="@field.Content"><i class="fa @field.Icon" aria-hidden="true"></i></a>
                                     }

--- a/src/Blogifier/Views/Themes/Vizew/Shared/Footer.cshtml
+++ b/src/Blogifier/Views/Themes/Vizew/Shared/Footer.cshtml
@@ -5,7 +5,6 @@
     var blog = await DataService.CustomFields.GetBlogSettings();
     var catsUnordered = await DataService.BlogPosts.Categories();
     var cats = catsUnordered.OrderByDescending(c => c.PostCount);
-    var socials = await DataService.CustomFields.GetSocial();
 }
 
 <!-- ##### Footer Area Start ##### -->
@@ -68,7 +67,7 @@
                     </div>
                     <!-- Footer Social Area -->
                     <div class="footer-social-area">
-                        @foreach (var field in socials)
+                        @foreach (var field in blog.SocialFields)
                         {
                         <a href="@field.Content" class="@field.Title.ToLower()"><i class="fa @field.Icon"></i></a>
                         }

--- a/src/Blogifier/Views/Themes/Vizew/Shared/Header.cshtml
+++ b/src/Blogifier/Views/Themes/Vizew/Shared/Header.cshtml
@@ -3,7 +3,6 @@
 @inject IJsonStringLocalizer<ListModel> Localizer
 @{
     var blog = await DataService.CustomFields.GetBlogSettings();
-    var socials = await DataService.CustomFields.GetSocial();
 }
 
 <!-- Preloader -->
@@ -29,7 +28,7 @@
                     <div class="top-meta-data d-flex align-items-center justify-content-end">
                         <!-- Top Social Info -->
                         <div class="top-social-info">
-                            @foreach (var field in socials)
+                            @foreach (var field in blog.SocialFields)
                             {
                             <a href="@field.Content"><i class="fa @field.Icon"></i></a>
                             }


### PR DESCRIPTION
Changes so that social buttons are invluded within the returning object for either blog settings or the post settings.

- Removed redundant calls to services from view
 - If post settings will obtain the social settings for the user that made the ost
- Tested on all 4 current themes
- Relies on https://github.com/blogifierdotnet/Blogifier.Core/pull/1