### PR TITLE
Misspelled unit test:

### DIFF
--- a/src/Blogifier.Core.Tests/Extensions/StringExtensionsTests.cs
+++ b/src/Blogifier.Core.Tests/Extensions/StringExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Blogifier.Core.Tests.Extensions
         [InlineData("http://foo/bar/img.jpg", "http://foo/bar/thumbs/img.jpg")]
         [InlineData("foo/bar//img-foo.jpg", "foo/bar//thumbs/img-foo.jpg")]
         [InlineData("foo/bar/img.one.png", "foo/bar/thumbs/img.one.png")]
-        public void ShouldConvertImgPathToTumbPath(string img, string thumb)
+        public void ShouldConvertImgPathToThumbPath(string img, string thumb)
         {
             Assert.Equal(img.ToThumb(), thumb);
         }


### PR DESCRIPTION
Blogifier.Core.Tests.Extensions.StringExtensionTests.ShouldConvertImgPathToTumbPath ->
Blogifier.Core.Tests.Extensions.StringExtensionTests.ShouldConvertImgPathToThumbPath

solves #210 