### PR TITLE
Resolve a problem with Obsolete controller

### DIFF
--- a/src/Blogifier.Core/Services/MailKitService.cs
+++ b/src/Blogifier.Core/Services/MailKitService.cs
@@ -22,7 +22,7 @@ namespace Blogifier.Core.Services
 
                 var message = new MimeMessage();
                 message.From.Add(new MailboxAddress(fromName, fromEmail));
-                message.To.Add(new MailboxAddress(toEmail));
+                message.To.Add(new MailboxAddress(fromName, toEmail));
                 message.Subject = subject;
 
                 var bodyBuilder = new BodyBuilder();

--- a/src/Blogifier/Blogifier.csproj
+++ b/src/Blogifier/Blogifier.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
     <PackageReference Include="Demo.BlazorChartist" Version="0.1.0-20200124.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="3.1.3"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The MailboxAddress uses an Obsolete constructor. The problem is resolved by adding the name of the sender.