### PR TITLE
filter admin page for non admin authors

### DIFF
--- a/src/Blogifier/Components/Dashboard/Counters.razor
+++ b/src/Blogifier/Components/Dashboard/Counters.razor
@@ -32,6 +32,8 @@
     private Task<AuthenticationState> AuthenticationStateTask { get; set; }
     [Parameter]
     public EventCallback<string> OnUpdate { get; set; }
+    [Parameter]
+    public string OfAuthor { get; set; }
     protected HttpRequest Request { get; set; }
 
     public Totals Totals { get; set; }
@@ -45,7 +47,7 @@
     public async Task Load()
     {
         var authState = await AuthenticationStateTask;
-        Totals = await Http.GetJsonAsync<Totals>($"analytics/counts", Request);
+        Totals = await Http.GetJsonAsync<Totals>($"analytics/counts?author={OfAuthor}", Request);
         StateHasChanged();
     }
 

--- a/src/Blogifier/Components/Dashboard/PostListWidget.razor
+++ b/src/Blogifier/Components/Dashboard/PostListWidget.razor
@@ -138,6 +138,9 @@
     [CascadingParameter]
     private Task<AuthenticationState> AuthenticationStateTask { get; set; }
 
+    [Parameter]
+    public string OfAuthor { get; set; }
+
     PageListModel pageListModel { get; set; }
     protected string SearchTerm { get; set; }
     protected int PostId { get; set; }
@@ -183,6 +186,7 @@
             if (FilterValue == PublishedStatus.Drafts) qString += "&include=D";
             if (FilterValue == PublishedStatus.Published) qString += "&include=FP";
             if (FilterValue == PublishedStatus.Featured) qString += "&include=F";
+            if (!string.IsNullOrEmpty(OfAuthor)) qString += "&author=" + OfAuthor;
 
             if (string.IsNullOrEmpty(SearchTerm))
             {

--- a/src/Blogifier/Pages/Admin/Index.razor
+++ b/src/Blogifier/Pages/Admin/Index.razor
@@ -1,23 +1,45 @@
 ﻿@page "/admin"
 @using Blogifier.Components.Profile
 @using Blogifier.Components.Dashboard
+@inject CustomHttpClient Http
+@inject IHttpContextAccessor HttpContextAccessor
 
-<div class="app-dashboard row no-gutters">
-    <div class="app-dashboard-posts col-lg-8">
-        <PostListWidget />
+@if (!_isInitialized)
+{
+    <div>Loading...</div>
+}
+else
+{
+    <div class="app-dashboard row no-gutters">
+        <div class="app-dashboard-posts col-lg-8">
+            <PostListWidget OfAuthor="@_postsOfAuthor" />
+        </div>
+        <div class="app-dashboard-widgets col-lg-4">
+            <ProfileWidget/>
+            <Counters @ref="CountersInstance" OfAuthor="@_postsOfAuthor" OnUpdate="UpdateHandler"/>
+            <Analytics/>
+            <CustomWidget/>
+        </div>
     </div>
-    <div class="app-dashboard-widgets col-lg-4">
-        <ProfileWidget />
-        <Counters @ref="CountersInstance" OnUpdate="UpdateHandler" />
-        <Analytics />
-        <CustomWidget />
-    </div>
-</div>
+}
 
 @code {
 
-    //PostsWidget PostsWidgetInstance;
     Counters CountersInstance;
+
+    bool _isInitialized;
+    string _postsOfAuthor;
+
+    protected override async Task OnInitializedAsync()
+    {
+         var author = await Http.GetJsonAsync<Author>($"authors/{HttpContextAccessor.HttpContext.User.Identity.Name}", HttpContextAccessor.HttpContext.Request);
+         if (author != null && !author.IsAdmin)
+         {
+             _postsOfAuthor = author.AppUserName;
+         }
+
+        _isInitialized = true;
+    }
 
     async Task UpdateHandler(string msg)
     {


### PR DESCRIPTION
The blog was originally planned for use by multiple authors
I would like to keep this functionality in the base module, for this it is enough to add filtering by the current author.

For a personal blog, this behavior will not break anything, since the admin sees all posts. Accordingly, the default user will see everything; in the case of multiplayer mode, each author will see only their posts (which is logical).