### PR TITLE
add sitemap generation

### DIFF
--- a/src/Blogifier.Models/AppModel.cs
+++ b/src/Blogifier.Models/AppModel.cs
@@ -10,6 +10,7 @@ namespace Blogifier.Models
         public string ImageExtensions { get; set; } = "png,jpg,jpeg,gif,bmp,tiff";
         public string ImportTypes { get; set; } = "zip,7z,xml,pdf,doc,docx,xls,xlsx,mp3,avi";
         public bool SeedData { get; set; }
+        public string SitemapBaseUri { get; set; }
     }
 
     public class BlogItem

--- a/src/Blogifier/Blogifier.csproj
+++ b/src/Blogifier/Blogifier.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
     <PackageReference Include="Demo.BlazorChartist" Version="0.1.0-20200124.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="3.1.3"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="3.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Blogifier/Controllers/IntegrationController.cs
+++ b/src/Blogifier/Controllers/IntegrationController.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Linq;
+using System.Xml.Linq;
+using Blogifier.Core.Data;
+using Blogifier.Core.Services;
+using Blogifier.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Blogifier.Controllers
+{
+    public class IntegrationController : ControllerBase
+    {
+        private readonly IDataService _data;
+        private readonly IOptionsMonitor<AppItem> _appSettingsMonitor;
+
+        public IntegrationController(IDataService data, IOptionsMonitor<AppItem> appSettingsMonitor)
+        {
+            _data = data;
+            _appSettingsMonitor = appSettingsMonitor;
+        }
+        
+        [Route("sitemap")]
+        [Produces("text/xml")]
+        public IActionResult Sitemap()
+        {
+            var sitemapNamespace = XNamespace.Get("http://www.sitemaps.org/schemas/sitemap/0.9");
+
+            var posts = _data.BlogPosts.Find(p => p.Published > DateTime.MinValue).OrderByDescending(p => p.Published);
+
+            var doc = new XDocument(
+                new XDeclaration("1.0", "utf-8", null),
+                new XElement(sitemapNamespace + "urlset", 
+                    from post in posts
+                    select new XElement(sitemapNamespace + "url", 
+                        new XElement(sitemapNamespace + "loc", GetPostUrl(post)),
+                        new XElement(sitemapNamespace + "lastmod", GetPostDate(post)),
+                        new XElement(sitemapNamespace + "changefreq", "monthly")
+                    )
+                )
+            );
+            
+            return Content(doc.Declaration + Environment.NewLine + doc, "text/xml");
+        }
+
+        public string GetPostUrl(BlogPost post)
+        {
+            var sitemapBaseUri = _appSettingsMonitor.CurrentValue.SitemapBaseUri;
+            if (string.IsNullOrEmpty(_appSettingsMonitor.CurrentValue.SitemapBaseUri))
+            {
+                sitemapBaseUri = $"{Request.Scheme}://{Request.Host}";
+            }
+
+            return $"{sitemapBaseUri}/posts/{post.Slug}";
+        }
+
+        public string GetPostDate(BlogPost post)
+        {
+            return post.Published.ToString("yyyy-MM-ddTHH:mm:sszzz");
+        }
+    }
+}

--- a/src/Blogifier/appsettings.json
+++ b/src/Blogifier/appsettings.json
@@ -10,6 +10,7 @@
     "DbProvider": "SQLite",
     "ConnString": "DataSource=Blog.db",
     "Avatar": "admin/img/avatar.png",
+    "SitemapBaseUri": "",
 
     "SendGridApiKey": "YOUR-SENDGRID-API-KEY",
     "SendGridEmailFrom": "admin@blog.com",


### PR DESCRIPTION
Add sitemap generation, which is used by search engines (google, yandex, bing, etc) to find information on the site faster.
This allows you to quickly send information about a new article, so that it would be indexed.